### PR TITLE
3.8.0a3 Fedora patches

### DIFF
--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -12,6 +12,8 @@ from distutils.sysconfig import get_python_version
 from distutils import log
 
 class bdist_wininst(Command):
+    # Marker for tests that we have the unsupported bdist_wininst
+    _unsupported = True
 
     description = "create an executable installer for MS Windows"
 

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -30,14 +30,14 @@ WINDOWS_SCHEME = {
 INSTALL_SCHEMES = {
     'unix_prefix': {
         'purelib': '$base/lib/python$py_version_short/site-packages',
-        'platlib': '$platbase/lib/python$py_version_short/site-packages',
+        'platlib': '$platbase/lib64/python$py_version_short/site-packages',
         'headers': '$base/include/python$py_version_short$abiflags/$dist_name',
         'scripts': '$base/bin',
         'data'   : '$base',
         },
     'unix_home': {
         'purelib': '$base/lib/python',
-        'platlib': '$base/lib/python',
+        'platlib': '$base/lib64/python',
         'headers': '$base/include/python/$dist_name',
         'scripts': '$base/bin',
         'data'   : '$base',

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -418,8 +418,19 @@ class install(Command):
                     raise DistutilsOptionError(
                           "must not supply exec-prefix without prefix")
 
-                self.prefix = os.path.normpath(sys.prefix)
-                self.exec_prefix = os.path.normpath(sys.exec_prefix)
+                # self.prefix is set to sys.prefix + /local/
+                # if neither RPM build nor virtual environment is
+                # detected to make pip and distutils install packages
+                # into the separate location.
+                if (not (hasattr(sys, 'real_prefix') or
+                    sys.prefix != sys.base_prefix) and
+                    'RPM_BUILD_ROOT' not in os.environ):
+                    addition = "/local"
+                else:
+                    addition = ""
+
+                self.prefix = os.path.normpath(sys.prefix) + addition
+                self.exec_prefix = os.path.normpath(sys.exec_prefix) + addition
 
             else:
                 if self.exec_prefix is None:

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -140,8 +140,12 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
             prefix = plat_specific and EXEC_PREFIX or PREFIX
 
     if os.name == "posix":
+        if plat_specific or standard_lib:
+            lib = "lib64"
+        else:
+            lib = "lib"
         libpython = os.path.join(prefix,
-                                 "lib", "python" + get_python_version())
+                                 lib, "python" + get_python_version())
         if standard_lib:
             return libpython
         else:

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -367,7 +367,10 @@ def parse_makefile(fn, g=None):
                     done[n] = item = ""
                 if found:
                     after = value[m.end():]
-                    value = value[:m.start()] + item + after
+                    value = value[:m.start()]
+                    if item.strip() not in value:
+                        value += item
+                    value += after
                     if "$" in after:
                         notdone[name] = value
                     else:

--- a/Lib/distutils/tests/test_install.py
+++ b/Lib/distutils/tests/test_install.py
@@ -57,8 +57,9 @@ class InstallTestCase(support.TempdirManager,
             self.assertEqual(got, expected)
 
         libdir = os.path.join(destination, "lib", "python")
+        platlibdir = os.path.join(destination, "lib64", "python")
         check_path(cmd.install_lib, libdir)
-        check_path(cmd.install_platlib, libdir)
+        check_path(cmd.install_platlib, platlibdir)
         check_path(cmd.install_purelib, libdir)
         check_path(cmd.install_headers,
                    os.path.join(destination, "include", "python", "foopkg"))

--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -82,6 +82,15 @@ class UnixCCompiler(CCompiler):
     if sys.platform == "cygwin":
         exe_extension = ".exe"
 
+    def _fix_lib_args(self, libraries, library_dirs, runtime_library_dirs):
+        """Remove standard library path from rpath"""
+        libraries, library_dirs, runtime_library_dirs = super()._fix_lib_args(
+            libraries, library_dirs, runtime_library_dirs)
+        libdir = sysconfig.get_config_var('LIBDIR')
+        if runtime_library_dirs and (libdir in runtime_library_dirs):
+            runtime_library_dirs.remove(libdir)
+        return libraries, library_dirs, runtime_library_dirs
+
     def preprocess(self, source, output_file=None, macros=None,
                    include_dirs=None, extra_preargs=None, extra_postargs=None):
         fixed_args = self._fix_compile_args(None, macros, include_dirs)

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -1,16 +1,27 @@
+import distutils.version
+import glob
 import os
 import os.path
-import pkgutil
 import sys
 import tempfile
 
 
 __all__ = ["version", "bootstrap"]
 
+_WHEEL_DIR = "/usr/share/python-wheels/"
 
-_SETUPTOOLS_VERSION = "40.8.0"
 
-_PIP_VERSION = "19.0.3"
+def _get_most_recent_wheel_version(pkg):
+    prefix = os.path.join(_WHEEL_DIR, "{}-".format(pkg))
+    suffix = "-py2.py3-none-any.whl"
+    pattern = "{}*{}".format(prefix, suffix)
+    versions = (p[len(prefix):-len(suffix)] for p in glob.glob(pattern))
+    return str(max(versions, key=distutils.version.LooseVersion))
+
+
+_SETUPTOOLS_VERSION = _get_most_recent_wheel_version("setuptools")
+
+_PIP_VERSION = _get_most_recent_wheel_version("pip")
 
 _PROJECTS = [
     ("setuptools", _SETUPTOOLS_VERSION),
@@ -94,12 +105,9 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         additional_paths = []
         for project, version in _PROJECTS:
             wheel_name = "{}-{}-py2.py3-none-any.whl".format(project, version)
-            whl = pkgutil.get_data(
-                "ensurepip",
-                "_bundled/{}".format(wheel_name),
-            )
-            with open(os.path.join(tmpdir, wheel_name), "wb") as fp:
-                fp.write(whl)
+            with open(os.path.join(_WHEEL_DIR, wheel_name), "rb") as sfp:
+                with open(os.path.join(tmpdir, wheel_name), "wb") as fp:
+                    fp.write(sfp.read())
 
             additional_paths.append(os.path.join(tmpdir, wheel_name))
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -334,11 +334,15 @@ def getsitepackages(prefixes=None):
         seen.add(prefix)
 
         if os.sep == '/':
+            sitepackages.append(os.path.join(prefix, "lib64",
+                                        "python" + sys.version[:3],
+                                        "site-packages"))
             sitepackages.append(os.path.join(prefix, "lib",
                                         "python%d.%d" % sys.version_info[:2],
                                         "site-packages"))
         else:
             sitepackages.append(prefix)
+            sitepackages.append(os.path.join(prefix, "lib64", "site-packages"))
             sitepackages.append(os.path.join(prefix, "lib", "site-packages"))
     return sitepackages
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -347,7 +347,14 @@ def getsitepackages(prefixes=None):
     return sitepackages
 
 def addsitepackages(known_paths, prefixes=None):
-    """Add site-packages to sys.path"""
+    """Add site-packages to sys.path
+
+    '/usr/local' is included in PREFIXES if RPM build is not detected
+    to make packages installed into this location visible.
+
+    """
+    if ENABLE_USER_SITE and 'RPM_BUILD_ROOT' not in os.environ:
+        PREFIXES.insert(0, "/usr/local")
     for sitedir in getsitepackages(prefixes):
         if os.path.isdir(sitedir):
             addsitedir(sitedir, known_paths)

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -20,10 +20,10 @@ __all__ = [
 
 _INSTALL_SCHEMES = {
     'posix_prefix': {
-        'stdlib': '{installed_base}/lib/python{py_version_short}',
-        'platstdlib': '{platbase}/lib/python{py_version_short}',
+        'stdlib': '{installed_base}/lib64/python{py_version_short}',
+        'platstdlib': '{platbase}/lib64/python{py_version_short}',
         'purelib': '{base}/lib/python{py_version_short}/site-packages',
-        'platlib': '{platbase}/lib/python{py_version_short}/site-packages',
+        'platlib': '{platbase}/lib64/python{py_version_short}/site-packages',
         'include':
             '{installed_base}/include/python{py_version_short}{abiflags}',
         'platinclude':
@@ -62,10 +62,10 @@ _INSTALL_SCHEMES = {
         'data': '{userbase}',
         },
     'posix_user': {
-        'stdlib': '{userbase}/lib/python{py_version_short}',
-        'platstdlib': '{userbase}/lib/python{py_version_short}',
+        'stdlib': '{userbase}/lib64/python{py_version_short}',
+        'platstdlib': '{userbase}/lib64/python{py_version_short}',
         'purelib': '{userbase}/lib/python{py_version_short}/site-packages',
-        'platlib': '{userbase}/lib/python{py_version_short}/site-packages',
+        'platlib': '{userbase}/lib64/python{py_version_short}/site-packages',
         'include': '{userbase}/include/python{py_version_short}',
         'scripts': '{userbase}/bin',
         'data': '{userbase}',

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -295,7 +295,10 @@ def _parse_makefile(filename, vars=None):
 
                 if found:
                     after = value[m.end():]
-                    value = value[:m.start()] + item + after
+                    value = value[:m.start()]
+                    if item.strip() not in value:
+                        value += item
+                    value += after
                     if "$" in after:
                         notdone[name] = value
                     else:

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -266,8 +266,8 @@ class HelperFunctionsTests(unittest.TestCase):
         dirs = site.getsitepackages()
         if os.sep == '/':
             # OS X, Linux, FreeBSD, etc
-            self.assertEqual(len(dirs), 1)
-            wanted = os.path.join('xoxo', 'lib',
+            self.assertEqual(len(dirs), 2)
+            wanted = os.path.join('xoxo', 'lib64',
                                   'python%d.%d' % sys.version_info[:2],
                                   'site-packages')
             self.assertEqual(dirs[0], wanted)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -556,7 +556,7 @@ clinic: check-clean-src $(srcdir)/Modules/_blake2/blake2s_impl.c
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/clinic/clinic.py --make --srcdir $(srcdir)
 
 # Build the interpreter
-$(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
+$(BUILDPYTHON):	Programs/python.o $(LDLIBRARY) $(PY3LIBRARY)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
 platform: $(BUILDPYTHON) pybuilddir.txt
@@ -603,12 +603,6 @@ sharedmods: $(BUILDPYTHON) pybuilddir.txt Modules/_math.o
 	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
 		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
 		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
-
-
-# Build static library
-$(LIBRARY): $(LIBRARY_OBJS)
-	-rm -f $@
-	$(AR) $(ARFLAGS) $@ $(LIBRARY_OBJS)
 
 libpython$(LDVERSION).so: $(LIBRARY_OBJS) $(DTRACE_OBJS)
 	if test $(INSTSONAME) != $(LDLIBRARY); then \
@@ -687,7 +681,7 @@ Makefile Modules/config.c: Makefile.pre \
 	@echo "The Makefile was updated, you may need to re-run make."
 
 
-Programs/_testembed: Programs/_testembed.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
+Programs/_testembed: Programs/_testembed.o $(LDLIBRARY) $(PY3LIBRARY)
 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/_testembed.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
 ############################################################################
@@ -1517,17 +1511,6 @@ libainstall:	@DEF_MAKE_RULE@ python-config
 		else	true; \
 		fi; \
 	done
-	@if test -d $(LIBRARY); then :; else \
-		if test "$(PYTHONFRAMEWORKDIR)" = no-framework; then \
-			if test "$(SHLIB_SUFFIX)" = .dll; then \
-				$(INSTALL_DATA) $(LDLIBRARY) $(DESTDIR)$(LIBPL) ; \
-			else \
-				$(INSTALL_DATA) $(LIBRARY) $(DESTDIR)$(LIBPL)/$(LIBRARY) ; \
-			fi; \
-		else \
-			echo Skip install of $(LIBRARY) - use make frameworkinstall; \
-		fi; \
-	fi
 	$(INSTALL_DATA) Modules/config.c $(DESTDIR)$(LIBPL)/config.c
 	$(INSTALL_DATA) Programs/python.o $(DESTDIR)$(LIBPL)/python.o
 	$(INSTALL_DATA) $(srcdir)/Modules/config.c.in $(DESTDIR)$(LIBPL)/config.c.in

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -140,7 +140,7 @@ LIBDIR=		@libdir@
 MANDIR=		@mandir@
 INCLUDEDIR=	@includedir@
 CONFINCLUDEDIR=	$(exec_prefix)/include
-SCRIPTDIR=	$(prefix)/lib
+SCRIPTDIR=	$(prefix)/lib64
 ABIFLAGS=	@ABIFLAGS@
 
 # Detailed destination directories

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1497,7 +1497,7 @@ inclinstall:
 
 # Install the library and miscellaneous stuff needed for extending/embedding
 # This goes into $(exec_prefix)
-LIBPL=		@LIBPL@
+LIBPL=		$(LIBDEST)/config-$(LDVERSION)-$(MULTIARCH)
 
 # pkgconfig directory
 LIBPC=		$(LIBDIR)/pkgconfig

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -688,7 +688,7 @@ calculate_exec_prefix(const _PyCoreConfig *core_config,
         if (safe_wcscpy(exec_prefix, calculate->exec_prefix, exec_prefix_len) < 0) {
             return PATHLEN_ERR();
         }
-        err = joinpath(exec_prefix, L"lib/lib-dynload", exec_prefix_len);
+        err = joinpath(exec_prefix, L"lib64/lib-dynload", exec_prefix_len);
         if (_Py_INIT_FAILED(err)) {
             return err;
         }
@@ -1015,7 +1015,7 @@ calculate_zip_path(PyCalculatePath *calculate, const wchar_t *prefix)
             return PATHLEN_ERR();
         }
     }
-    err = joinpath(calculate->zip_path, L"lib/python00.zip", zip_path_len);
+    err = joinpath(calculate->zip_path, L"lib64/python00.zip", zip_path_len);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -1144,7 +1144,7 @@ calculate_init(PyCalculatePath *calculate,
     if (!calculate->prefix) {
         return DECODE_LOCALE_ERR("EXEC_PREFIX define", len);
     }
-    calculate->lib_python = Py_DecodeLocale("lib/python" VERSION, &len);
+    calculate->lib_python = Py_DecodeLocale("lib64/python" VERSION, &len);
     if (!calculate->lib_python) {
         return DECODE_LOCALE_ERR("EXEC_PREFIX define", len);
     }

--- a/config.sub
+++ b/config.sub
@@ -1042,7 +1042,7 @@ case $basic_machine in
 		;;
 	ppc64)	basic_machine=powerpc64-unknown
 		;;
-	ppc64-*) basic_machine=powerpc64-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+	ppc64-* | ppc64p7-*) basic_machine=powerpc64-`echo "$basic_machine" | sed 's/^[^-]*-//'`
 		;;
 	ppc64le | powerpc64little)
 		basic_machine=powerpc64le-unknown

--- a/configure.ac
+++ b/configure.ac
@@ -739,9 +739,9 @@ cat >> conftest.c <<EOF
         alpha-linux-gnu
 # elif defined(__ARM_EABI__) && defined(__ARM_PCS_VFP)
 #  if defined(__ARMEL__)
-        arm-linux-gnueabihf
+        arm-linux-gnueabi
 #  else
-        armeb-linux-gnueabihf
+        armeb-linux-gnueabi
 #  endif
 # elif defined(__ARM_EABI__) && !defined(__ARM_PCS_VFP)
 #  if defined(__ARMEL__)
@@ -781,7 +781,7 @@ cat >> conftest.c <<EOF
 #  elif _MIPS_SIM == _ABIN32
         mips64el-linux-gnuabin32
 #  elif _MIPS_SIM == _ABI64
-        mips64el-linux-gnuabi64
+        mips64el-linux-gnu
 #  else
 #   error unknown platform triplet
 #  endif
@@ -791,22 +791,22 @@ cat >> conftest.c <<EOF
 #  elif _MIPS_SIM == _ABIN32
         mips64-linux-gnuabin32
 #  elif _MIPS_SIM == _ABI64
-        mips64-linux-gnuabi64
+        mips64-linux-gnu
 #  else
 #   error unknown platform triplet
 #  endif
 # elif defined(__or1k__)
         or1k-linux-gnu
 # elif defined(__powerpc__) && defined(__SPE__)
-        powerpc-linux-gnuspe
+        ppc-linux-gnuspe
 # elif defined(__powerpc64__)
 #  if defined(__LITTLE_ENDIAN__)
-        powerpc64le-linux-gnu
+        ppc64le-linux-gnu
 #  else
-        powerpc64-linux-gnu
+        ppc64-linux-gnu
 #  endif
 # elif defined(__powerpc__)
-        powerpc-linux-gnu
+        ppc-linux-gnu
 # elif defined(__s390x__)
         s390x-linux-gnu
 # elif defined(__s390__)

--- a/setup.py
+++ b/setup.py
@@ -610,7 +610,7 @@ class PyBuildExt(build_ext):
         # directories (i.e. '.' and 'Include') must be first.  See issue
         # 10520.
         if not CROSS_COMPILING:
-            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib64')
             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
         # only change this for cross builds for 3.3, issues on Mageia
         if CROSS_COMPILING:
@@ -902,11 +902,11 @@ class PyBuildExt(build_ext):
             elif curses_library:
                 readline_libs.append(curses_library)
             elif self.compiler.find_library_file(self.lib_dirs +
-                                                     ['/usr/lib/termcap'],
+                                                     ['/usr/lib64/termcap'],
                                                      'termcap'):
                 readline_libs.append('termcap')
             self.add(Extension('readline', ['readline.c'],
-                               library_dirs=['/usr/lib/termcap'],
+                               library_dirs=['/usr/lib64/termcap'],
                                extra_link_args=readline_extra_link_args,
                                libraries=readline_libs))
         else:


### PR DESCRIPTION
Those are all of our patches as of 3.8.0a3 in Fedora rawhide (31).

This was HEAD: https://src.fedoraproject.org/rpms/python38/c/084a366e3d465801793c881800b016a776ba7c68

I've applied the patches, using dates where they were introduced (except some of the initial patches, where I've used the date of python3 package initial import), I've also tried to attribute all authors (except some of the initial patches, where I didn't bother to digg deeper than to attribute David Malcolm).

@vstinner and @stratakis Please review if the patches reflect the reality. If you find something wrong in our patches, note it down, we should address that later. 

On Monday, a4 should be released, I'll just take this and rebase it on that tag.

Thanks