### PR TITLE
00328: Restore pyc to TIMESTAMP invalidation mode as default in rpmbuild

### DIFF
--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -70,7 +70,8 @@ class PycInvalidationMode(enum.Enum):
 
 
 def _get_default_invalidation_mode():
-    if os.environ.get('SOURCE_DATE_EPOCH'):
+    if (os.environ.get('SOURCE_DATE_EPOCH') and not
+            os.environ.get('RPM_BUILD_ROOT')):
         return PycInvalidationMode.CHECKED_HASH
     else:
         return PycInvalidationMode.TIMESTAMP

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -17,6 +17,7 @@ def without_source_date_epoch(fxn):
     def wrapper(*args, **kwargs):
         with support.EnvironmentVarGuard() as env:
             env.unset('SOURCE_DATE_EPOCH')
+            env.unset('RPM_BUILD_ROOT')
             return fxn(*args, **kwargs)
     return wrapper
 
@@ -27,6 +28,7 @@ def with_source_date_epoch(fxn):
     def wrapper(*args, **kwargs):
         with support.EnvironmentVarGuard() as env:
             env['SOURCE_DATE_EPOCH'] = '123456789'
+            env.unset('RPM_BUILD_ROOT')
             return fxn(*args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
Since Fedora 31, the $SOURCE_DATE_EPOCH is set in rpmbuild to the latest
%changelog date. This makes Python default to the CHECKED_HASH pyc
invalidation mode, bringing more reproducible builds traded for an import
performance decrease. To avoid that, we don't default to CHECKED_HASH
when $RPM_BUILD_ROOT is set (i.e. when we are building RPM packages).

See https://src.fedoraproject.org/rpms/redhat-rpm-config/pull-request/57#comment-27426

Untested yet. Will run a scratchbuild.