### PR TITLE
00353: Original names for architectures with different names downstream

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1566,7 +1566,7 @@ def _get_supported_file_loaders():
 
     Each item is a tuple (loader, suffixes).
     """
-    extensions = ExtensionFileLoader, _imp.extension_suffixes()
+    extensions = ExtensionFileLoader, _alternative_architectures(_imp.extension_suffixes())
     source = SourceFileLoader, SOURCE_SUFFIXES
     bytecode = SourcelessFileLoader, BYTECODE_SUFFIXES
     return [extensions, source, bytecode]
@@ -1622,7 +1622,7 @@ def _setup(_bootstrap_module):
 
     # Constants
     setattr(self_module, '_relax_case', _make_relax_case())
-    EXTENSION_SUFFIXES.extend(_imp.extension_suffixes())
+    EXTENSION_SUFFIXES.extend(_alternative_architectures(_imp.extension_suffixes()))
     if builtin_os == 'nt':
         SOURCE_SUFFIXES.append('.pyw')
         if '_d.pyd' in EXTENSION_SUFFIXES:
@@ -1635,3 +1635,30 @@ def _install(_bootstrap_module):
     supported_loaders = _get_supported_file_loaders()
     sys.path_hooks.extend([FileFinder.path_hook(*supported_loaders)])
     sys.meta_path.append(PathFinder)
+
+
+_ARCH_MAP = {
+    "-arm-linux-gnueabi.": "-arm-linux-gnueabihf.",
+    "-armeb-linux-gnueabi.": "-armeb-linux-gnueabihf.",
+    "-mips64-linux-gnu.": "-mips64-linux-gnuabi64.",
+    "-mips64el-linux-gnu.": "-mips64el-linux-gnuabi64.",
+    "-ppc-linux-gnu.": "-powerpc-linux-gnu.",
+    "-ppc-linux-gnuspe.": "-powerpc-linux-gnuspe.",
+    "-ppc64-linux-gnu.": "-powerpc64-linux-gnu.",
+    "-ppc64le-linux-gnu.": "-powerpc64le-linux-gnu.",
+}
+
+
+def _alternative_architectures(suffixes):
+    """Add a suffix with an alternative architecture name
+    to the list of suffixes so an extension built with
+    the default (upstream) setting is loadable with our Pythons
+    """
+
+    for suffix in suffixes:
+        for original, alternative in _ARCH_MAP.items():
+            if original in suffix:
+                suffixes.append(suffix.replace(original, alternative))
+                return suffixes
+
+    return suffixes


### PR DESCRIPTION
Pythons in RHEL/Fedora use different names for some architectures
than upstream and other distros (for example ppc64 vs. powerpc64).
See patch 274.
That means that an extension built with the default upstream settings
(on other distro or as an manylinux wheel) cannot be found by Python
on RHEL/Fedora because it has a different suffix.
This patch adds the original names to importlib so Python is able
to import extensions with an original architecture name in its
file name.

Tested on ppc64le with a wheel from simple-manylinux-demo:
```
# pip3 install simple-manylinux-demo
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting simple-manylinux-demo
  Downloading simple_manylinux_demo-1.0-cp39-cp39-manylinux2014_ppc64le.whl (17 kB)
Installing collected packages: simple-manylinux-demo
Successfully installed simple-manylinux-demo-1.0
# default Python
# python3 -m unittest discover dummyextension.tests
E
======================================================================
ERROR: dummyextension.tests.test_extension (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: dummyextension.tests.test_extension
Traceback (most recent call last):
  File "/usr/lib64/python3.9/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib64/python3.9/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/usr/local/lib64/python3.9/site-packages/dummyextension/tests/test_extension.py", line 2, in <module>
    from dummyextension.extension import hello
ModuleNotFoundError: No module named 'dummyextension.extension'


----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
# ll /usr/local/lib64/python3.9/site-packages/dummyextension/
total 88
-rwxr-xr-x. 1 root root 88832 Aug  3 04:14 extension.cpython-39-powerpc64le-linux-gnu.so
-rw-r--r--. 1 root root     0 Aug  3 04:14 __init__.py
drwxr-xr-x. 2 root root    37 Aug  3 04:14 __pycache__
drwxr-xr-x. 3 root root    69 Aug  3 04:14 tests
# Patched version
# python3 -m unittest discover dummyextension.tests
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
# New loader registered for the longer name
>>> import sys
>>> sys.path_importer_cache
{'/usr/lib64/python39.zip': None, '/usr/lib64/python3.9': FileFinder('/usr/lib64/python3.9'), '/usr/lib64/python3.9/encodings': FileFinder('/usr/lib64/python3.9/encodings'), '/usr/lib64/python3.9/lib-dynload': FileFinder('/usr/lib64/python3.9/lib-dynload'), '/usr/local/lib64/python3.9/site-packages': FileFinder('/usr/local/lib64/python3.9/site-packages'), '/usr/lib64/python3.9/site-packages': FileFinder('/usr/lib64/python3.9/site-packages'), '/usr/lib/python3.9/site-packages': FileFinder('/usr/lib/python3.9/site-packages'), '/root': FileFinder('/root')}
>>> ff = sys.path_importer_cache['/usr/lib64/python3.9/site-packages']
>>> ff._loaders
[('.cpython-39-ppc64le-linux-gnu.so', <class '_frozen_importlib_external.ExtensionFileLoader'>), ('.abi3.so', <class '_frozen_importlib_external.ExtensionFileLoader'>), ('.so', <class '_frozen_importlib_external.ExtensionFileLoader'>), ('.cpython-39-powerpc64le-linux-gnu.so', <class '_frozen_importlib_external.ExtensionFileLoader'>), ('.py', <class '_frozen_importlib_external.SourceFileLoader'>), ('.pyc', <class '_frozen_importlib_external.SourcelessFileLoader'>)]
```

This might be also implemented on C level somewhere around _PyImport_DynLoadFiletab but I think that this version is much clearer and easy to understand.