### PR TITLE
Fix test_dbm_gnu & allocation alignment (FTBFS on ppc64le and x86-64)

### DIFF
--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -250,7 +250,11 @@ typedef union _gc_head {
         union _gc_head *gc_prev;
         Py_ssize_t gc_refs;
     } gc;
-    double dummy;  /* force worst-case alignment */
+    long double dummy;  /* force worst-case alignment */
+    // malloc returns memory block aligned for any built-in types and
+    // long double is the largest standard C type.
+    // On amd64 linux, long double requires 16 byte alignment.
+    // See bpo-27987 for more discussion.
 } PyGC_Head;
 
 extern PyGC_Head *_PyGC_generation0;

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1372,7 +1372,7 @@ def _get_supported_file_loaders():
 
     Each item is a tuple (loader, suffixes).
     """
-    extensions = ExtensionFileLoader, _imp.extension_suffixes()
+    extensions = ExtensionFileLoader, _alternative_architectures(_imp.extension_suffixes())
     source = SourceFileLoader, SOURCE_SUFFIXES
     bytecode = SourcelessFileLoader, BYTECODE_SUFFIXES
     return [extensions, source, bytecode]
@@ -1439,7 +1439,7 @@ def _setup(_bootstrap_module):
 
     # Constants
     setattr(self_module, '_relax_case', _make_relax_case())
-    EXTENSION_SUFFIXES.extend(_imp.extension_suffixes())
+    EXTENSION_SUFFIXES.extend(_alternative_architectures(_imp.extension_suffixes()))
     if builtin_os == 'nt':
         SOURCE_SUFFIXES.append('.pyw')
         if '_d.pyd' in EXTENSION_SUFFIXES:
@@ -1459,3 +1459,39 @@ def _install(_bootstrap_module):
     # a setuptools bug (https://bitbucket.org/pypa/setuptools/issue/378).
     _bootstrap_module.FileFinder = FileFinder
     _bootstrap_module.SourceFileLoader = SourceFileLoader
+
+
+_ARCH_MAP = {
+    "-arm-linux-gnueabi.": "-arm-linux-gnueabihf.",
+    "-armeb-linux-gnueabi.": "-armeb-linux-gnueabihf.",
+    "-mips64-linux-gnu.": "-mips64-linux-gnuabi64.",
+    "-mips64el-linux-gnu.": "-mips64el-linux-gnuabi64.",
+    "-ppc-linux-gnu.": "-powerpc-linux-gnu.",
+    "-ppc-linux-gnuspe.": "-powerpc-linux-gnuspe.",
+    "-ppc64-linux-gnu.": "-powerpc64-linux-gnu.",
+    "-ppc64le-linux-gnu.": "-powerpc64le-linux-gnu.",
+    # The above, but the other way around:
+    "-arm-linux-gnueabihf.": "-arm-linux-gnueabi.",
+    "-armeb-linux-gnueabihf.": "-armeb-linux-gnueabi.",
+    "-mips64-linux-gnuabi64.": "-mips64-linux-gnu.",
+    "-mips64el-linux-gnuabi64.": "-mips64el-linux-gnu.",
+    "-powerpc-linux-gnu.": "-ppc-linux-gnu.",
+    "-powerpc-linux-gnuspe.": "-ppc-linux-gnuspe.",
+    "-powerpc64-linux-gnu.": "-ppc64-linux-gnu.",
+    "-powerpc64le-linux-gnu.": "-ppc64le-linux-gnu.",
+}
+
+
+def _alternative_architectures(suffixes):
+    """Add a suffix with an alternative architecture name
+    to the list of suffixes so an extension built with
+    the default (upstream) setting is loadable with our Pythons
+    """
+
+    for suffix in suffixes:
+        for original, alternative in _ARCH_MAP.items():
+            if original in suffix:
+                suffixes.append(suffix.replace(original, alternative))
+                return suffixes
+
+    return suffixes

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -69,9 +69,13 @@ class TestGdbm(unittest.TestCase):
         self.g = gdbm.open(filename, 'c')
         size0 = os.path.getsize(filename)
 
-        self.g['x'] = 'x' * 10000
+        # bpo-33901: on macOS with gdbm 1.15, an empty database uses 16 MiB
+        # and adding an entry of 10,000 B has no effect on the file size.
+        # Add size0 bytes to make sure that the file size changes.
+        value_size = max(size0, 10000)
+        self.g['x'] = 'x' * value_size
         size1 = os.path.getsize(filename)
-        self.assertTrue(size0 < size1)
+        self.assertGreater(size1, size0)
 
         del self.g['x']
         # 'size' is supposed to be the same even after deleting an entry.
@@ -79,7 +83,8 @@ class TestGdbm(unittest.TestCase):
 
         self.g.reorganize()
         size2 = os.path.getsize(filename)
-        self.assertTrue(size1 > size2 >= size0)
+        self.assertLess(size2, size1)
+        self.assertGreaterEqual(size2, size0)
 
     def test_context_manager(self):
         with gdbm.open(filename, 'c') as db:

--- a/Lib/test/test_email/test_utils.py
+++ b/Lib/test/test_email/test_utils.py
@@ -75,6 +75,7 @@ class LocaltimeTests(unittest.TestCase):
         t2 = utils.localtime(t1)
         self.assertEqual(t1, t2)
 
+    @test.support.run_with_tz('Europe/Minsk')
     def test_localtime_daylight_true_dst_true(self):
         test.support.patch(self, time, 'daylight', True)
         t0 = datetime.datetime(2012, 3, 12, 1, 1)
@@ -82,6 +83,7 @@ class LocaltimeTests(unittest.TestCase):
         t2 = utils.localtime(t1)
         self.assertEqual(t1, t2)
 
+    @test.support.run_with_tz('Europe/Minsk')
     def test_localtime_daylight_false_dst_true(self):
         test.support.patch(self, time, 'daylight', False)
         t0 = datetime.datetime(2012, 3, 12, 1, 1)

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -148,9 +148,6 @@ class ResourceTest(unittest.TestCase):
     @support.requires_linux_version(2, 6, 36)
     def test_prlimit(self):
         self.assertRaises(TypeError, resource.prlimit)
-        if os.geteuid() != 0:
-            self.assertRaises(PermissionError, resource.prlimit,
-                              1, resource.RLIMIT_AS)
         self.assertRaises(ProcessLookupError, resource.prlimit,
                           -1, resource.RLIMIT_AS)
         limit = resource.getrlimit(resource.RLIMIT_AS)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
@@ -1,0 +1,3 @@
+pymalloc returns memory blocks aligned by 16 bytes, instead of 8 bytes, on
+64-bit platforms to conform x86-64 ABI. Recent compilers assume this alignment
+more often. Patch by Inada Naoki.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
@@ -1,0 +1,2 @@
+``PyGC_Head`` structure is aligned to ``long double``.  This is needed to
+ensure GC-ed objects are aligned properly.  Patch by Inada Naoki.

--- a/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
@@ -1,0 +1,2 @@
+Fix test_dbm_gnu on macOS with gdbm 1.15: add a larger value to make sure that
+the file size changes.

--- a/Misc/NEWS.d/next/Tests/2018-11-26-16-54-21.bpo-35317.jByGP2.rst
+++ b/Misc/NEWS.d/next/Tests/2018-11-26-16-54-21.bpo-35317.jByGP2.rst
@@ -1,0 +1,3 @@
+Fix ``mktime()`` overflow error in ``test_email``: run
+``test_localtime_daylight_true_dst_true()`` and
+``test_localtime_daylight_false_dst_true()`` with a specific timezone.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -952,18 +952,15 @@ faulthandler_fatal_error_py(PyObject *self, PyObject *args)
 }
 
 #if defined(HAVE_SIGALTSTACK) && defined(HAVE_SIGACTION)
-#ifdef __INTEL_COMPILER
-   /* Issue #23654: Turn off ICC's tail call optimization for the
-    * stack_overflow generator. ICC turns the recursive tail call into
-    * a loop. */
-#  pragma intel optimization_level 0
-#endif
 static
 Py_uintptr_t
 stack_overflow(Py_uintptr_t min_sp, Py_uintptr_t max_sp, size_t *depth)
 {
-    /* allocate 4096 bytes on the stack at each call */
-    unsigned char buffer[4096];
+    /* Allocate (at least) 4096 bytes on the stack at each call.
+
+       bpo-23654, bpo-38965: use volatile keyword to prevent tail call
+       optimization. */
+    volatile unsigned char buffer[4096];
     Py_uintptr_t sp = (Py_uintptr_t)&buffer;
     *depth += 1;
     if (sp < min_sp || max_sp < sp)
@@ -1146,7 +1143,11 @@ int _PyFaulthandler_Init(void)
      * be able to allocate memory on the stack, even on a stack overflow. If it
      * fails, ignore the error. */
     stack.ss_flags = 0;
-    stack.ss_size = SIGSTKSZ;
+    /* bpo-21131: allocate dedicated stack of SIGSTKSZ*2 bytes, instead of just
+       SIGSTKSZ bytes. Calling the previous signal handler in faulthandler
+       signal handler uses more than SIGSTKSZ bytes of stack memory on some
+       platforms. */
+    stack.ss_size = SIGSTKSZ * 2;
     stack.ss_sp = PyMem_Malloc(stack.ss_size);
     if (stack.ss_sp != NULL) {
         err = sigaltstack(&stack, &old_stack);

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -540,8 +540,14 @@ static int running_on_valgrind = -1;
  *
  * You shouldn't change this unless you know what you are doing.
  */
+
+#if SIZEOF_VOID_P > 4
+#define ALIGNMENT              16               /* must be 2^N */
+#define ALIGNMENT_SHIFT         4
+#else
 #define ALIGNMENT               8               /* must be 2^N */
 #define ALIGNMENT_SHIFT         3
+#endif
 
 /* Return the number of bytes in size class I, as a uint. */
 #define INDEX2SIZE(I) (((uint)(I) + 1) << ALIGNMENT_SHIFT)

--- a/configure
+++ b/configure
@@ -783,6 +783,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -895,6 +896,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1147,6 +1149,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1284,7 +1295,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1437,6 +1448,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR	  modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -11290,7 +11302,7 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
  getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
  if_nameindex \
- initgroups kill killpg lchmod lchown lockf linkat lstat lutimes mmap \
+ initgroups kill killpg lchown lockf linkat lstat lutimes mmap \
  memrchr mbrtowc mkdirat mkfifo \
  mkfifoat mknod mknodat mktime mremap nice openat pathconf pause pipe2 plock poll \
  posix_fallocate posix_fadvise pread \
@@ -11316,6 +11328,22 @@ _ACEOF
 fi
 done
 
+# Force lchmod off for Linux. Linux disallows changing the mode of symbolic
+# links. Some libc implementations have a stub lchmod implementation that always
+# returns an error.
+if test "$MACHDEP" != linux; then
+  for ac_func in lchmod
+do :
+  ac_fn_c_check_func "$LINENO" "lchmod" "ac_cv_func_lchmod"
+if test "x$ac_cv_func_lchmod" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LCHMOD 1
+_ACEOF
+
+fi
+done
+
+fi
 
 ac_fn_c_check_decl "$LINENO" "dirfd" "ac_cv_have_decl_dirfd" "#include <sys/types.h>
        #include <dirent.h>

--- a/configure.ac
+++ b/configure.ac
@@ -3370,7 +3370,7 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
  getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
  if_nameindex \
- initgroups kill killpg lchmod lchown lockf linkat lstat lutimes mmap \
+ initgroups kill killpg lchown lockf linkat lstat lutimes mmap \
  memrchr mbrtowc mkdirat mkfifo \
  mkfifoat mknod mknodat mktime mremap nice openat pathconf pause pipe2 plock poll \
  posix_fallocate posix_fadvise pread \
@@ -3385,6 +3385,13 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
  wcscoll wcsftime wcsxfrm wmemcmp writev _getpty)
+
+# Force lchmod off for Linux. Linux disallows changing the mode of symbolic
+# links. Some libc implementations have a stub lchmod implementation that always
+# returns an error.
+if test "$MACHDEP" != linux; then
+  AC_CHECK_FUNCS(lchmod)
+fi
 
 AC_CHECK_DECL(dirfd,
     AC_DEFINE(HAVE_DIRFD, 1,


### PR DESCRIPTION
This inserts patch 00311, taken from https://bugs.python.org/issue33901
Upstream lists the fix as being for macOS, but apparently it's ppc64le-specific (and probably specific to gdbm 1.15+).

Github shows all commits on top of 00311 in the diff; a direct comparison is here: https://github.com/fedora-python/cpython/compare/fedora-3.5..encukou:fedora-3.5