### PR TITLE
[DO NOT MERGE] fixup! 00251: Change user install location

### DIFF
--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -70,7 +70,8 @@ class PycInvalidationMode(enum.Enum):
 
 
 def _get_default_invalidation_mode():
-    if os.environ.get('SOURCE_DATE_EPOCH'):
+    if (os.environ.get('SOURCE_DATE_EPOCH') and not
+            os.environ.get('RPM_BUILD_ROOT')):
         return PycInvalidationMode.CHECKED_HASH
     else:
         return PycInvalidationMode.TIMESTAMP

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -380,8 +380,15 @@ def getsitepackages(prefixes=None):
     return sitepackages
 
 def addsitepackages(known_paths, prefixes=None):
-    """Add site-packages to sys.path"""
+    """Add site-packages to sys.path
+
+    '/usr/local' is included in PREFIXES if RPM build is not detected
+    to make packages installed into this location visible.
+
+    """
     _trace("Processing global site-packages")
+    if ENABLE_USER_SITE and 'RPM_BUILD_ROOT' not in os.environ:
+        PREFIXES.insert(0, "/usr/local")
     for sitedir in getsitepackages(prefixes):
         if os.path.isdir(sitedir):
             addsitedir(sitedir, known_paths)

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -63,7 +63,8 @@ _INSTALL_SCHEMES = {
 _INSTALL_SCHEMES['rpm_prefix'] = _INSTALL_SCHEMES['posix_prefix']
 # Virtualenv from 20.10.0 favors a new "venv" scheme over the defaults.
 # See: https://github.com/pypa/virtualenv/commit/8da79db86d8a5c74d03667a40e64ff832076445e
-# "venv" should be the same as the default for us.
+# "venv" should be the same as the unpatched posix_prefix for us,
+# so new virtual environments aren't created with paths like venv/local/bin/python.
 _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['posix_prefix']
 
 if (not (hasattr(sys, 'real_prefix') or

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -61,6 +61,10 @@ _INSTALL_SCHEMES = {
 # backup the original posix_prefix as rpm_prefix
 # RPM packages use it and we need to be able to read it even when changed
 _INSTALL_SCHEMES['rpm_prefix'] = _INSTALL_SCHEMES['posix_prefix']
+# Virtualenv from 20.10.0 favors a new "venv" scheme over the defaults.
+# See: https://github.com/pypa/virtualenv/commit/8da79db86d8a5c74d03667a40e64ff832076445e
+# "venv" should be the same as the default for us.
+_INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['posix_prefix']
 
 if (not (hasattr(sys, 'real_prefix') or
     sys.prefix != sys.base_prefix) and

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -63,6 +63,7 @@ _INSTALL_SCHEMES = {
 _INSTALL_SCHEMES['rpm_prefix'] = _INSTALL_SCHEMES['posix_prefix']
 # Virtualenv from 20.10.0 favors a new "venv" scheme over the defaults.
 # See: https://github.com/pypa/virtualenv/commit/8da79db86d8a5c74d03667a40e64ff832076445e
+# See: https://bugs.python.org/issue45413
 # "venv" should be the same as the unpatched posix_prefix for us,
 # so new virtual environments aren't created with paths like venv/local/bin/python.
 _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['posix_prefix']

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -61,7 +61,7 @@ _INSTALL_SCHEMES = {
 # backup the original posix_prefix as rpm_prefix
 # RPM packages use it and we need to be able to read it even when changed
 _INSTALL_SCHEMES['rpm_prefix'] = _INSTALL_SCHEMES['posix_prefix']
-# Virtualenv from 20.10.0 favors a new "venv" scheme over the defaults.
+# Virtualenv >= 20.10.0 favors the "venv" scheme over the defaults when creating virtual environments.
 # See: https://github.com/pypa/virtualenv/commit/8da79db86d8a5c74d03667a40e64ff832076445e
 # See: https://bugs.python.org/issue45413
 # "venv" should be the same as the unpatched posix_prefix for us,

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -58,6 +58,25 @@ _INSTALL_SCHEMES = {
         },
     }
 
+# backup the original posix_prefix as rpm_prefix
+# RPM packages use it and we need to be able to read it even when changed
+_INSTALL_SCHEMES['rpm_prefix'] = _INSTALL_SCHEMES['posix_prefix']
+
+if (not (hasattr(sys, 'real_prefix') or
+    sys.prefix != sys.base_prefix) and
+    'RPM_BUILD_ROOT' not in os.environ):
+        _INSTALL_SCHEMES['posix_prefix'] = {
+            'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
+            'platstdlib': '{platbase}/{platlibdir}/python{py_version_short}',
+            'purelib': '{base}/local/lib/python{py_version_short}/site-packages',
+            'platlib': '{platbase}/local/{platlibdir}/python{py_version_short}/site-packages',
+            'include':
+                '{installed_base}/include/python{py_version_short}{abiflags}',
+            'platinclude':
+                '{installed_platbase}/include/python{py_version_short}{abiflags}',
+            'scripts': '{base}/local/bin',
+            'data': '{base}/local',
+        }
 
 # NOTE: site.py has copy of this function.
 # Sync it when modify this function.

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -19,6 +19,7 @@ def without_source_date_epoch(fxn):
     def wrapper(*args, **kwargs):
         with os_helper.EnvironmentVarGuard() as env:
             env.unset('SOURCE_DATE_EPOCH')
+            env.unset('RPM_BUILD_ROOT')
             return fxn(*args, **kwargs)
     return wrapper
 
@@ -29,6 +30,7 @@ def with_source_date_epoch(fxn):
     def wrapper(*args, **kwargs):
         with os_helper.EnvironmentVarGuard() as env:
             env['SOURCE_DATE_EPOCH'] = '123456789'
+            env.unset('RPM_BUILD_ROOT')
             return fxn(*args, **kwargs)
     return wrapper
 

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -263,7 +263,7 @@ class TestSysConfig(unittest.TestCase):
         self.assertTrue(os.path.isfile(config_h), config_h)
 
     def test_get_scheme_names(self):
-        wanted = ['nt', 'posix_home', 'posix_prefix', 'rpm_prefix']
+        wanted = ['nt', 'posix_home', 'posix_prefix', 'rpm_prefix', 'venv']
         if HAS_USER_BASE:
             wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -263,7 +263,7 @@ class TestSysConfig(unittest.TestCase):
         self.assertTrue(os.path.isfile(config_h), config_h)
 
     def test_get_scheme_names(self):
-        wanted = ['nt', 'posix_home', 'posix_prefix']
+        wanted = ['nt', 'posix_home', 'posix_prefix', 'rpm_prefix']
         if HAS_USER_BASE:
             wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
@@ -274,6 +274,8 @@ class TestSysConfig(unittest.TestCase):
             cmd = "-c", "import sysconfig; print(sysconfig.get_platform())"
             self.assertEqual(py.call_real(*cmd), py.call_link(*cmd))
 
+    @unittest.skipIf('RPM_BUILD_ROOT' not in os.environ,
+                     "Test doesn't expect Fedora's paths")
     def test_user_similar(self):
         # Issue #8759: make sure the posix scheme for the users
         # is similar to the global posix_prefix one


### PR DESCRIPTION
This is an udpated version of patch 251 for Python 3.10 + 3.11 in rawhide. Virtualenv now prefers "venv" scheme if exists and because we need the patch to not affect virtualenv there is a new "venv" scheme as a copy of the original one before we add the `/local` prefixes to it.

Manually tested and it seems to work fine. Builds are available in: https://copr.fedorainfracloud.org/coprs/lbalhar/venv_scheme/builds/

If approved, I'm gonna squash this commit to the original one and force-push it to the 3.10 and 3.11 branches.