### PR TITLE
00375: Fix test_distance to enable build on i686

### DIFF
--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -220,7 +220,7 @@ class TestVec2D(VectorComparisonMixin, unittest.TestCase):
     def test_distance(self):
         vec = Vec2D(6, 8)
         expected = 10
-        self.assertEqual(abs(vec), expected)
+        self.assertAlmostEqual(abs(vec), expected)
 
         vec = Vec2D(0, 0)
         expected = 0
@@ -228,7 +228,7 @@ class TestVec2D(VectorComparisonMixin, unittest.TestCase):
 
         vec = Vec2D(2.5, 6)
         expected = 6.5
-        self.assertEqual(abs(vec), expected)
+        self.assertAlmostEqual(abs(vec), expected)
 
     def test_rotate(self):
 


### PR DESCRIPTION
Fedora's [Koji scratch build](https://koji.fedoraproject.org/koji/taskinfo?taskID=81753515) passed on all architectures with this patch.