### PR TITLE
00406-cve-2022-48565.patch

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -390,6 +390,11 @@ class Data:
         return "%s(%s)" % (self.__class__.__name__, repr(self.data))
 
 
+class InvalidFileException (ValueError):
+    def __init__(self, message="Invalid file"):
+        ValueError.__init__(self, message)
+
+
 class PlistParser:
 
     def __init__(self):
@@ -403,8 +408,15 @@ class PlistParser:
         parser.StartElementHandler = self.handleBeginElement
         parser.EndElementHandler = self.handleEndElement
         parser.CharacterDataHandler = self.handleData
+        parser.EntityDeclHandler = self.handle_entity_decl
         parser.ParseFile(fileobj)
         return self.root
+
+    def handle_entity_decl(self, entity_name, is_parameter_entity, value, base, system_id, public_id, notation_name):
+        # Reject plist files with entity declarations to avoid XML vulnerabilies in expat.
+        # Regular plist files don't contain those declerations, and Apple's plutil tool does not
+        # accept them either.
+        raise InvalidFileException("XML entity declarations are not supported in plist files")
 
     def handleBeginElement(self, element, attrs):
         self.data = []

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -86,6 +86,19 @@ TESTDATA = """<?xml version="1.0" encoding="UTF-8"?>
 </plist>
 """.replace(" " * 8, "\t")  # Apple as well as plistlib.py output hard tabs
 
+XML_PLIST_WITH_ENTITY=b'''\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd" [
+   <!ENTITY entity "replacement text">
+  ]>
+<plist version="1.0">
+  <dict>
+    <key>A</key>
+    <string>&entity;</string>
+  </dict>
+</plist>
+'''
+
 
 class TestPlistlib(unittest.TestCase):
 
@@ -194,6 +207,11 @@ class TestPlistlib(unittest.TestCase):
         result2 = plistlib.readPlistFromString(plistlib.writePlistToString(test2))
         self.assertEqual(test1, result1)
         self.assertEqual(test2, result2)
+
+    def test_xml_plist_with_entity_decl(self):
+        with self.assertRaisesRegexp(plistlib.InvalidFileException,
+                                     "XML entity declarations are not supported"):
+            plistlib.readPlistFromString(XML_PLIST_WITH_ENTITY)
 
 
 def test_main():

--- a/Misc/NEWS.d/next/Security/2020-10-19-10-56-27.bpo-42051.EU_B7u.rst
+++ b/Misc/NEWS.d/next/Security/2020-10-19-10-56-27.bpo-42051.EU_B7u.rst
@@ -1,0 +1,3 @@
+The :mod:`plistlib` module no longer accepts entity declarations in XML
+plist files to avoid XML vulnerabilities. This should not affect users as
+entity declarations are not used in regular plist files.


### PR DESCRIPTION
CVE-2022-48565: XML External Entity in XML processing plistlib module Backported from https://github.com/python/cpython/commit/a158fb9c5138db94adf24fbc5690467cda811163 Tracking bug: https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2022-48565