### PR TITLE
00418: Don't generate sbom in make regen-all

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1364,10 +1364,11 @@ regen-unicodedata:
 regen-all: regen-cases regen-typeslots \
 	regen-token regen-ast regen-keyword regen-sre regen-frozen \
 	regen-pegen-metaparser regen-pegen regen-test-frozenmain \
-	regen-test-levenshtein regen-global-objects regen-sbom
+	regen-test-levenshtein regen-global-objects
 	@echo
 	@echo "Note: make regen-stdlib-module-names, make regen-limited-abi, "
-	@echo "make regen-configure and make regen-unicodedata should be run manually"
+	@echo "make regen-configure, make regen-unicodedata and make regen-sbom "
+	@echo "should be run manually"
 
 ############################################################################
 # Special rules for object files


### PR DESCRIPTION
The script and make target, added in Python 3.13.0a3, assumes a fixed location of pip wheel and other bundled libraries, resulting in an error and failed build when not found.
Reported upstream: https://github.com/python/cpython/issues/114240 and https://github.com/python/cpython/issues/114244

