### PR TITLE
Optimize 251 a tiny bit

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -306,7 +306,7 @@ def _expand_vars(scheme, vars):
     # we only change the defaults here, so explicit --prefix will take precedence
     # https://fedoraproject.org/wiki/Changes/Making_sudo_pip_safe
     if (scheme == 'posix_prefix' and
-         get_config_vars('prefix')[0] == '/usr' and
+        sys.prefix == '/usr' and
         'RPM_BUILD_ROOT' not in os.environ):
             _extend_dict(vars, _config_vars_local())
     else:


### PR DESCRIPTION
Before:

```
$ python3.14 -m timeit -s 'import sysconfig' 'sysconfig.get_paths()'
2000 loops, best of 5: 157 usec per loop

$ python3.14 -m timeit -s 'import sysconfig' 'sysconfig.get_paths()'
2000 loops, best of 5: 162 usec per loop

$ python3.14 -m timeit -s 'import sysconfig' 'sysconfig.get_paths()'
1000 loops, best of 5: 146 usec per loop
```

After:

```
$ python3.14 -m timeit -s 'import sysconfig' 'sysconfig.get_paths()'
5000 loops, best of 5: 75.9 usec per loop

$ python3.14 -m timeit -s 'import sysconfig' 'sysconfig.get_paths()'
5000 loops, best of 5: 77.1 usec per loop

$ python3.14 -m timeit -s 'import sysconfig' 'sysconfig.get_paths()'
5000 loops, best of 5: 76.2 usec per loop
```