### PR TITLE
[3.9] 00452: Properly apply exported CFLAGS for dtrace/systemtap builds

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -989,7 +989,7 @@ Python/frozen.o: $(srcdir)/Python/importlib.h $(srcdir)/Python/importlib_externa
 # an include guard, so we can't use a pipeline to transform its output.
 Include/pydtrace_probes.h: $(srcdir)/Include/pydtrace.d
 	$(MKDIR_P) Include
-	$(DTRACE) $(DFLAGS) -o $@ -h -s $<
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(DTRACE) $(DFLAGS) -o $@ -h -s $<
 	: sed in-place edit with POSIX-only tools
 	sed 's/PYTHON_/PyDTrace_/' $@ > $@.tmp
 	mv $@.tmp $@
@@ -999,7 +999,7 @@ Python/import.o: $(srcdir)/Include/pydtrace.h
 Modules/gcmodule.o: $(srcdir)/Include/pydtrace.h
 
 Python/pydtrace.o: $(srcdir)/Include/pydtrace.d $(DTRACE_DEPS)
-	$(DTRACE) $(DFLAGS) -o $@ -G -s $< $(DTRACE_DEPS)
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(DTRACE) $(DFLAGS) -o $@ -G -s $< $(DTRACE_DEPS)
 
 Objects/typeobject.o: Objects/typeslots.inc
 

--- a/Misc/NEWS.d/next/Build/2025-03-31-19-22-41.gh-issue-131865.PIJy7X.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-31-19-22-41.gh-issue-131865.PIJy7X.rst
@@ -1,0 +1,2 @@
+The DTrace build now properly passes the ``CC`` and ``CFLAGS`` variables
+to the ``dtrace`` command when utilizing SystemTap on Linux.


### PR DESCRIPTION
When using --with-dtrace the resulting object file could be missing specific CFLAGS exported by the build system due to the systemtap script using specific defaults.

Exporting the CC and CFLAGS variables before the dtrace invocation allows us to properly apply CFLAGS exported by the build system even when cross-compiling.