### PR TITLE
00457: ssl: Raise OSError for ERR_LIB_SYS

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -638,6 +638,11 @@ PySSL_SetError(PySSLSocket *obj, int ret, const char *filename, int lineno)
                     errstr = "Some I/O error occurred";
                 }
             } else {
+                if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
+                    // A system error is being reported; reason is set to errno
+                    errno = ERR_GET_REASON(e);
+                    return PyErr_SetFromErrno(PyExc_OSError);
+                }
                 p = PY_SSL_ERROR_SYSCALL;
             }
             break;
@@ -648,6 +653,11 @@ PySSL_SetError(PySSLSocket *obj, int ret, const char *filename, int lineno)
             if (e == 0)
                 /* possible? */
                 errstr = "A failure in the SSL library occurred";
+            if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
+                // A system error is being reported; reason is set to errno
+                errno = ERR_GET_REASON(e);
+                return PyErr_SetFromErrno(PyExc_OSError);
+            }
             break;
         }
         default:


### PR DESCRIPTION
The patch resolves the flakiness of test_ftplib

Backported from upstream 3.10+:
https://github.com/python/cpython/pull/127361

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
