### PR TITLE
[3.12] 00464: Enable PAC and BTI protections for aarch64

### DIFF
--- a/Python/asm_trampoline.S
+++ b/Python/asm_trampoline.S
@@ -1,3 +1,5 @@
+#include "asm_trampoline_aarch64.h"
+
     .text
     .globl	_Py_trampoline_func_start
 # The following assembly is equivalent to:
@@ -20,10 +22,12 @@ _Py_trampoline_func_start:
 #if defined(__aarch64__) && defined(__AARCH64EL__) && !defined(__ILP32__)
     // ARM64 little endian, 64bit ABI
     // generate with aarch64-linux-gnu-gcc 12.1
+    SIGN_LR
     stp     x29, x30, [sp, -16]!
     mov     x29, sp
     blr     x3
     ldp     x29, x30, [sp], 16
+    VERIFY_LR
     ret
 #endif
     .globl	_Py_trampoline_func_end

--- a/Python/asm_trampoline_aarch64.h
+++ b/Python/asm_trampoline_aarch64.h
@@ -1,0 +1,50 @@
+#ifndef ASM_TRAMPOLINE_AARCH_64_H_
+#define ASM_TRAMPOLINE_AARCH_64_H_
+
+/*
+ * References:
+ *  - https://developer.arm.com/documentation/101028/0012/5--Feature-test-macros
+ *  - https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst
+ */
+
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT == 1
+  #define BTI_J hint 36 /* bti j: for jumps, IE br instructions */
+  #define BTI_C hint 34  /* bti c: for calls, IE bl instructions */
+  #define GNU_PROPERTY_AARCH64_BTI 1 /* bit 0 GNU Notes is for BTI support */
+#else
+  #define BTI_J
+  #define BTI_C
+  #define GNU_PROPERTY_AARCH64_BTI 0
+#endif
+
+#if defined(__ARM_FEATURE_PAC_DEFAULT)
+  #if __ARM_FEATURE_PAC_DEFAULT & 1
+    #define SIGN_LR hint 25 /* paciasp: sign with the A key */
+    #define VERIFY_LR hint 29 /* autiasp: verify with the A key */
+  #elif __ARM_FEATURE_PAC_DEFAULT & 2
+    #define SIGN_LR hint 27 /* pacibsp: sign with the b key */
+    #define VERIFY_LR hint 31 /* autibsp: verify with the b key */
+  #endif
+  #define GNU_PROPERTY_AARCH64_POINTER_AUTH 2 /* bit 1 GNU Notes is for PAC support */
+#else
+  #define SIGN_LR BTI_C
+  #define VERIFY_LR
+  #define GNU_PROPERTY_AARCH64_POINTER_AUTH 0
+#endif
+
+/* Add the BTI and PAC support to GNU Notes section */
+#if GNU_PROPERTY_AARCH64_BTI != 0 || GNU_PROPERTY_AARCH64_POINTER_AUTH != 0
+    .pushsection .note.gnu.property, "a"; /* Start a new allocatable section */
+    .balign 8; /* align it on a byte boundry */
+    .long 4; /* size of "GNU\0" */
+    .long 0x10; /* size of descriptor */
+    .long 0x5; /* NT_GNU_PROPERTY_TYPE_0 */
+    .asciz "GNU";
+    .long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+    .long 4; /* Four bytes of data */
+    .long (GNU_PROPERTY_AARCH64_BTI|GNU_PROPERTY_AARCH64_POINTER_AUTH); /* BTI or PAC is enabled */
+    .long 0; /* padding for 8 byte alignment */
+    .popsection; /* end the section */
+#endif
+
+#endif


### PR DESCRIPTION
Apply protection against ROP/JOP attacks for aarch64 on asm_trampoline.S

The BTI flag must be applied in the assembler sources for this class of attacks to be mitigated on newer aarch64 processors.

Upstream PR: https://github.com/python/cpython/pull/130864/files

The upstream patch is incomplete but only for the case where frame pointers are not used on 3.13+.

Since on Fedora we always compile with frame pointers the BTI/PAC hardware protections can be enabled without losing Perf unwinding.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
