### PR TITLE
Raise an error when importing modules compiled for an older Python

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -116,6 +116,49 @@ struct PyModuleDef {
   freefunc m_free;
 };
 
+#if defined(_PyHack_check_version_on_modinit) && defined(Py_BUILD_CORE)
+/* The mechanism for the check has been implemented on Python 3.15+:
+ * https://github.com/python/cpython/pull/137212.
+ * In Fedora, we need this in older Pythons too:
+ * if somebody attempts to import a module compiled for a different Python version,
+ * instead of segmentation fault a meaningful error is raised.
+ */
+PyAPI_DATA(const unsigned long) Py_Version;
+
+static inline int
+_PyHack_CheckInternalAPIVersion(const char *mod_name)
+{
+    if (PY_VERSION_HEX != Py_Version) {
+        PyErr_Format(
+            PyExc_ImportError,
+            "internal Python C API version mismatch: "
+            "module %s compiled with %lu.%lu.%lu; "
+            "runtime version is %lu.%lu.%lu",
+            mod_name,
+            (const unsigned long)((PY_VERSION_HEX >> 24) & 0xFF),
+            (const unsigned long)((PY_VERSION_HEX >> 16) & 0xFF),
+            (const unsigned long)((PY_VERSION_HEX >> 8) & 0xFF),
+            (const unsigned long)((Py_Version >> 24) & 0xFF),
+            (const unsigned long)((Py_Version >> 16) & 0xFF),
+            (const unsigned long)((Py_Version >> 8) & 0xFF)
+        );
+        return -1;
+    }
+    return 0;
+}
+
+static inline PyObject *
+PyModuleDef_Init_with_check(PyModuleDef *def)
+{
+    if (_PyHack_CheckInternalAPIVersion(def->m_name) < 0) {
+        return NULL;
+    }
+    return PyModuleDef_Init(def);
+}
+
+#define PyModuleDef_Init PyModuleDef_Init_with_check
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3415,3 +3415,6 @@ MODULE__MULTIBYTECODEC_DEPS=$(srcdir)/Modules/cjkcodecs/multibytecodec.h
 # Local Variables:
 # mode: makefile
 # End:
+
+# Fedora-specific, downstream only
+PY_STDMODULE_CFLAGS += -D_PyHack_check_version_on_modinit=1

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3489,6 +3489,12 @@ static struct PyModuleDef _tkintermodule = {
 PyMODINIT_FUNC
 PyInit__tkinter(void)
 {
+    #ifdef _PyHack_check_version_on_modinit
+        if (_PyHack_CheckInternalAPIVersion("_tkinter") < 0) {
+            return NULL;
+        }
+    #endif
+
     PyObject *m, *uexe, *cexe;
 
     tcl_lock = PyThread_allocate_lock();

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -215,6 +215,12 @@ static struct PyModuleDef module_def = {
 PyMODINIT_FUNC
 PyInit__tracemalloc(void)
 {
+    #ifdef _PyHack_check_version_on_modinit
+        if (_PyHack_CheckInternalAPIVersion("_tracemalloc") < 0) {
+            return NULL;
+        }
+    #endif
+
     PyObject *mod = PyModule_Create(&module_def);
     if (mod == NULL) {
         return NULL;

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1604,6 +1604,12 @@ static struct PyModuleDef readlinemodule = {
 PyMODINIT_FUNC
 PyInit_readline(void)
 {
+    #ifdef _PyHack_check_version_on_modinit
+        if (_PyHack_CheckInternalAPIVersion("readline") < 0) {
+            return NULL;
+        }
+    #endif
+
     const char *backend = "readline";
     PyObject *m;
     readlinestate *mod_state;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -50,6 +50,7 @@ _PyModule_IsExtension(PyObject *obj)
 }
 
 
+#undef PyModuleDef_Init
 PyObject*
 PyModuleDef_Init(PyModuleDef* def)
 {


### PR DESCRIPTION
This is a downstream workaround for
https://github.com/python/cpython/issues/128341 -
it is resolved for Python 3.15+, but the issue happened again in the update from 3.14.2 to 3.14.3 (segfault when importing _pickle).
